### PR TITLE
Revert "finalize RangeCategoryOfHomomorphismStructure if not finalized"

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 PackageName := "IntrinsicModules",
 Subtitle := "Finitely presented modules over computable rings allowing multiple presentations and the notion of elements",
 
-Version := "2022.10-01",
+Version := "2022.10-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/IntrinsicModules.gi
+++ b/gap/IntrinsicModules.gi
@@ -214,11 +214,6 @@ BindGlobal( "CATEGORY_OF_HOMALG_MODULES",
     
     Finalize( A : FinalizeCategory := true );
     
-    if HasRangeCategoryOfHomomorphismStructure( A ) and
-       not IsFinalized( RangeCategoryOfHomomorphismStructure( A ) ) then
-        Finalize( RangeCategoryOfHomomorphismStructure( A ) : FinalizeCategory := true );
-    fi;
-
     A := CategoryWithAmbientObjects( A );
     
     A := IntrinsicCategory( A :


### PR DESCRIPTION
This reverts commit 85b3248c9909e48770b6eb42491a03319336a4ef.

https://github.com/homalg-project/CAP_project/pull/1094 has a better fix.